### PR TITLE
Test random fail fix

### DIFF
--- a/test/db.rb
+++ b/test/db.rb
@@ -32,7 +32,6 @@ class StiB < Sti; end
 class StiAA < StiA; end
 class StiAB < StiA; end
 class StiAAB < StiAA; end
-Class.new(StiA)
 
 module DB
   DATABASE_CONFIG = {


### PR DESCRIPTION
テストがたまにfailする原因修正、assert_equalのactualとexpectedが逆になってたの直した