### PR TITLE
batch load to avoid union select limits

### DIFF
--- a/lib/top_n_loader/sql_builder.rb
+++ b/lib/top_n_loader/sql_builder.rb
@@ -125,6 +125,10 @@ module TopNLoader::SQLBuilder
     end
   end
 
+  def self.values_table_batch_size
+    sqlite? ? 200 : 1000
+  end
+
   def self.nil_first?
     !postgres?
   end


### PR DESCRIPTION
`select v1 as column union select v2 union select v3 ...` の数がDBによって制限がある
```
sqlite: 500
mysql: 4000くらい 設定で違う
pg: 7200くらい(遅い・`values (),(), ...` が使えて速いし制限もっと緩いので関係ない)
```
sqliteは200 他は1000 毎にbatchでやる